### PR TITLE
updating import links for shim and peer package

### DIFF
--- a/artifacts/chaincode/iot_chaincode/cc.go
+++ b/artifacts/chaincode/iot_chaincode/cc.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hyperledger/fabric/core/chaincode/shim"
-	"github.com/hyperledger/fabric/protos/peer"
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	sc "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 //SmartContract


### PR DESCRIPTION
The shim and peer protobuf modules are no longer vendored automatically by Fabric, so they are needed to vendor individually otherwise they lead to the issue as depicted in the attached screenshot.

![chaincode_go_import-error](https://user-images.githubusercontent.com/48702793/131336350-772dcc95-7f49-4869-bc02-a5c556375d8c.png)